### PR TITLE
Fix duplicate filenames in export

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -104,7 +104,7 @@
       const chat = chats[i];
       const safeTitle = chat.title.replace(/[\\/:*?"<>|]/g, '').slice(0, 40);
       const text = `${chat.title}\n\n${chat.messages.join('\n\n')}`;
-      zip.file(`${safeTitle || "Untitled"}.txt`, text);
+      zip.file(`${safeTitle || "Untitled"}_${i}.txt`, text);
     });
 
     const blob = await zip.generateAsync({ type: "blob" });


### PR DESCRIPTION
## Summary
- update filename generation when exporting chats so every file is unique

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_686bda8951e4832596c7b5a4fd6d3562